### PR TITLE
Add a Robo command to set up a development environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Robo tasks to set up a Drupal installation.",
     "type": "robo-tasks",
     "require": {
-        "cweagans/composer-patches": "~1.6",
         "consolidation/robo": "~2"
     },
     "autoload": {
@@ -19,12 +18,5 @@
         }
     ],
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "extra": {
-        "patches": {
-            "consolidation/robo": {
-                "Add a method Robo::getCommandInstance": "https://github.com/consolidation/Robo/pull/675.patch"
-            }
-        }
-    }
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Robo tasks to set up a Drupal installation.",
     "type": "robo-tasks",
     "require": {
+        "cweagans/composer-patches": "~1.6",
         "consolidation/robo": "~2"
     },
     "autoload": {
@@ -17,5 +18,13 @@
             "email": "pieter@frenssen.be"
         }
     ],
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "patches": {
+            "consolidation/robo": {
+                "Add a method Robo::getCommandInstance": "https://github.com/consolidation/Robo/pull/675.patch"
+            }
+        }
+    }
 }

--- a/src/Robo/Plugin/Commands/ConfigFileCommands.php
+++ b/src/Robo/Plugin/Commands/ConfigFileCommands.php
@@ -4,8 +4,12 @@ declare(strict_types = 1);
 
 namespace CodeLab\RoboDrupalSetup\Robo\Plugin\Commands;
 
+use CodeLab\RoboDrupalSetup\Robo\Task\Tasks;
+
 class ConfigFileCommands extends \Robo\Tasks
 {
+
+    use Tasks;
 
     /**
      * Generates the behat.yml configuration file.
@@ -17,7 +21,7 @@ class ConfigFileCommands extends \Robo\Tasks
      */
     public function behatGenerateConfig(): void
     {
-        $this->generateConfig('behat.yml.dist', 'behat.yml');
+        $this->taskGenerateConfig('behat.yml.dist', 'behat.yml')->run();
     }
 
     /**
@@ -30,40 +34,7 @@ class ConfigFileCommands extends \Robo\Tasks
      */
     public function drushGenerateConfig(): void
     {
-        $this->generateConfig('drush/drush.yml.dist', 'drush/drush.yml');
-    }
-
-    /**
-     * Generates a configuration file.
-     *
-     * This will copy the source file to the destination file and replace any
-     * environment variables in it, as long as they are declared as
-     * `${ENV_VAR}`. If the destination file exists it will be overwritten.
-     *
-     * @param string $source
-     *   The path to the source file, relative to the project root.
-     * @param string $destination
-     *   The path to the destination file, relative to the project root.
-     */
-    protected function generateConfig(string $source, string $destination): void
-    {
-        $replace = [];
-
-        foreach (array_keys($_SERVER) as $env_var) {
-            $value = $_SERVER[$env_var];
-            if (is_scalar($value)) {
-                $replace['${' . $env_var . '}'] = $value;
-            }
-        }
-
-        $this->taskFilesystemStack()
-          ->copy($source, $destination, true)
-          ->run();
-
-        $this->taskReplaceInFile($destination)
-          ->from(array_keys($replace))
-          ->to(array_values($replace))
-          ->run();
+        $this->taskGenerateConfig('drush/drush.yml.dist', 'drush/drush.yml')->run();
     }
 
 }

--- a/src/Robo/Plugin/Commands/DevelopmentCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentCommands.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CodeLab\RoboDrupalSetup\Robo\Plugin\Commands;
+
+use CodeLab\RoboDrupalSetup\Robo\Task\Tasks;
+use Robo\Robo;
+
+class DevelopmentCommands extends \Robo\Tasks
+{
+
+    use Tasks;
+
+    /**
+     * Sets up a development environment.
+     *
+     * @command dev:setup
+     */
+    public function devSetup(): void
+    {
+        /** @var \CodeLab\RoboDrupalSetup\Robo\Plugin\Commands\ConfigFileCommands $config_file_commands */
+        $config_file_commands = Robo::getCommandInstance('ConfigFile');
+        $config_file_commands->behatGenerateConfig();
+        $config_file_commands->drushGenerateConfig();
+    }
+
+}

--- a/src/Robo/Plugin/Commands/DevelopmentCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentCommands.php
@@ -19,10 +19,12 @@ class DevelopmentCommands extends \Robo\Tasks
      */
     public function devSetup(): void
     {
-        /** @var \CodeLab\RoboDrupalSetup\Robo\Plugin\Commands\ConfigFileCommands $config_file_commands */
-        $config_file_commands = Robo::getCommandInstance('ConfigFile');
-        $config_file_commands->behatGenerateConfig();
-        $config_file_commands->drushGenerateConfig();
+        // @todo This is duplicating code from ConfigFileCommands. Call the
+        //   commands directly once there is a way to instantiate the command
+        //   class.
+        // @see https://github.com/consolidation/Robo/pull/675
+        $this->taskGenerateConfig('behat.yml.dist', 'behat.yml')->run();
+        $this->taskGenerateConfig('drush/drush.yml.dist', 'drush/drush.yml')->run();
     }
 
 }

--- a/src/Robo/Task/GenerateConfig.php
+++ b/src/Robo/Task/GenerateConfig.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CodeLab\RoboDrupalSetup\Robo\Task;
+
+use Robo\Common\BuilderAwareTrait;
+use Robo\Contract\BuilderAwareInterface;
+use Robo\Contract\TaskInterface;
+use Robo\Result;
+
+/**
+ * Generates a config file by replacing placeholders wih environment variables.
+ */
+class GenerateConfig implements TaskInterface, BuilderAwareInterface
+{
+
+    use BuilderAwareTrait;
+
+    /**
+     * The path to the source file, relative to the project root.
+     *
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * The path to the destination file, relative to the project root.
+     *
+     * @var string
+     */
+    protected $destination;
+
+    /**
+     * Constructs a GenerateConfig task.
+     */
+    public function __construct(string $source, string $destination)
+    {
+        $this->source = $source;
+        $this->destination = $destination;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function run(): Result
+    {
+        $replace = [];
+
+        foreach (array_keys($_SERVER) as $env_var) {
+            $value = $_SERVER[$env_var];
+            if (is_scalar($value)) {
+                $replace['${' . $env_var . '}'] = $value;
+            }
+        }
+
+        $collection = $this->collectionBuilder();
+        $collection->taskFilesystemStack()
+          ->copy($this->source, $this->destination, true);
+
+        $collection->taskReplaceInFile($this->destination)
+          ->from(array_keys($replace))
+          ->to(array_values($replace));
+
+        return $collection->run();
+    }
+
+}

--- a/src/Robo/Task/Tasks.php
+++ b/src/Robo/Task/Tasks.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CodeLab\RoboDrupalSetup\Robo\Task;
+
+use Robo\Contract\TaskInterface;
+
+/**
+ * Functions to load tasks.
+ */
+trait Tasks
+{
+
+    /**
+     * Returns a task to generate a configuration file.
+     *
+     * This will copy the source file to the destination file and replace any
+     * environment variables in it, as long as they are declared as
+     * `${ENV_VAR}`. If the destination file exists it will be overwritten.
+     *
+     * @param string $source
+     *   The path to the source file, relative to the project root.
+     * @param string $destination
+     *   The path to the destination file, relative to the project root.
+     *
+     * @return \CodeLab\RoboDrupalSetup\Robo\Task\GenerateConfig
+     *   The task.
+     */
+    protected function taskGenerateConfig(string $source, string $destination): TaskInterface
+    {
+        return $this->task(GenerateConfig::class, $source, $destination);
+    }
+
+}


### PR DESCRIPTION
Add a robo command `dev:setup` that will generate the configuration files using values suitable for a development environment. This should initially invoke the commands `behat:generate-config` and `drush:generate-config`.